### PR TITLE
Allow usage of arrays in addition to variadic arguments in Interval and Plan functions

### DIFF
--- a/Sources/Schedule/Interval.swift
+++ b/Sources/Schedule/Interval.swift
@@ -99,22 +99,28 @@ extension Interval {
     }
 
     /// Returns the longest interval of the given values.
+    /// - Note: Returns initialized with `init(nanoseconds: 0)` if given no parameters.
     public static func longest(_ intervals: Interval...) -> Interval {
         return Interval.longest(intervals)
     }
         
     /// Returns the longest interval of the given values.
+    /// - Note: Returns initialized with `init(nanoseconds: 0)` if given an empty array.
     public static func longest(_ intervals: [Interval]) -> Interval {
+        guard !intervals.isEmpty else { return .init(nanoseconds: 0) }
         return intervals.sorted(by: { $0.magnitude > $1.magnitude })[0]
     }
 
     /// Returns the shortest interval of the given values.
+    /// - Note: Returns initialized with `init(nanoseconds: 0)` if given no parameters.
     public static func shortest(_ intervals: Interval...) -> Interval {
         return Interval.shortest(intervals)
     }
     
     /// Returns the shortest interval of the given values.
+    /// - Note: Returns initialized with `init(nanoseconds: 0)` if given an empty array.
     public static func shortest(_ intervals: [Interval]) -> Interval {
+        guard !intervals.isEmpty else { return .init(nanoseconds: 0) }
         return intervals.sorted(by: { $0.magnitude < $1.magnitude })[0]
     }
 }

--- a/Sources/Schedule/Interval.swift
+++ b/Sources/Schedule/Interval.swift
@@ -100,11 +100,21 @@ extension Interval {
 
     /// Returns the longest interval of the given values.
     public static func longest(_ intervals: Interval...) -> Interval {
+        return Interval.longest(intervals)
+    }
+        
+    /// Returns the longest interval of the given values.
+    public static func longest(_ intervals: [Interval]) -> Interval {
         return intervals.sorted(by: { $0.magnitude > $1.magnitude })[0]
     }
 
     /// Returns the shortest interval of the given values.
     public static func shortest(_ intervals: Interval...) -> Interval {
+        return Interval.shortest(intervals)
+    }
+    
+    /// Returns the shortest interval of the given values.
+    public static func shortest(_ intervals: [Interval]) -> Interval {
         return intervals.sorted(by: { $0.magnitude < $1.magnitude })[0]
     }
 }

--- a/Sources/Schedule/Plan.swift
+++ b/Sources/Schedule/Plan.swift
@@ -495,3 +495,9 @@ extension Plan {
         return DateMiddleware(plan: plan)
     }
 }
+
+extension Plan: Equatable {
+    public static func == (lhs: Plan, rhs: Plan) -> Bool {
+        return lhs.sequence.elementsEqual(rhs.sequence)
+    }
+}

--- a/Sources/Schedule/Plan.swift
+++ b/Sources/Schedule/Plan.swift
@@ -83,13 +83,16 @@ extension Plan {
 
     /// Creates a plan from a list of intervals.
     /// The task will be executed after each interval in the array.
+    /// - Note: Returns `Plan.never` if given no parameters.
     public static func of(_ intervals: Interval...) -> Plan {
         return Plan.of(intervals)
     }
     
     /// Creates a plan from a list of intervals.
     /// The task will be executed after each interval in the array.
+    /// - Note: Returns `Plan.never` if given an empty array.
     public static func of(_ intervals: [Interval]) -> Plan {
+        guard !intervals.isEmpty else { return .never }
         return Plan(intervals)
     }
 }
@@ -141,13 +144,16 @@ extension Plan {
 
     /// Creates a plan from a list of dates.
     /// The task will be executed at each date in the array.
+    /// - Note: Returns `Plan.never` if given no parameters.
     public static func of(_ dates: Date...) -> Plan {
         return Plan.of(dates)
     }
     
     /// Creates a plan from a list of dates.
     /// The task will be executed at each date in the array.
+    /// - Note: Returns `Plan.never` if given no parameters.
     public static func of(_ dates: [Date]) -> Plan {
+        guard !dates.isEmpty else { return .never }
         return Plan.from(dates)
     }
 
@@ -347,6 +353,8 @@ extension Plan {
 
         /// Returns a plan at the specific time.
         public func at(_ time: Time) -> Plan {
+            guard self.plan != .never else { return .never }
+            
             var interval = time.intervalSinceZeroClock
             return Plan.make { () -> AnyIterator<Interval> in
                 let it = self.plan.makeIterator()
@@ -364,9 +372,13 @@ extension Plan {
         ///
         /// See Time's constructor
         public func at(_ time: String) -> Plan {
-            guard let time = Time(time) else {
-                return Plan.never
+            guard
+                self.plan != .never,
+                let time = Time(time)
+            else {
+                return .never
             }
+            
             return at(time)
         }
 
@@ -376,6 +388,8 @@ extension Plan {
         ///     .at(1, 2)           => 01:02
         ///     .at(1, 2, 3)        => 01:02:03
         ///     .at(1, 2, 3, 456)   => 01:02:03.456
+        ///
+        /// - Note: Returns `Plan.never` if given no parameters.
         public func at(_ time: Int...) -> Plan {
             return self.at(time)
         }
@@ -386,7 +400,11 @@ extension Plan {
         ///     .at([1, 2])           => 01:02
         ///     .at([1, 2, 3])        => 01:02:03
         ///     .at([1, 2, 3, 456])   => 01:02:03.456
+        ///
+        /// - Note: Returns `Plan.never` if given an empty array.
         public func at(_ time: [Int]) -> Plan {
+            guard !time.isEmpty, self.plan != .never else { return .never }
+            
             let hour = time[0]
             let minute = time.count > 1 ? time[1] : 0
             let second = time.count > 2 ? time[2] : 0
@@ -419,12 +437,16 @@ extension Plan {
     }
 
     /// Creates a plan that executes the task every specific weekdays.
+    /// - Note: Returns initialized with `Plan.never` if given no parameters.
     public static func every(_ weekdays: Weekday...) -> DateMiddleware {
         return Plan.every(weekdays)
     }
     
     /// Creates a plan that executes the task every specific weekdays.
+    /// - Note: Returns initialized with `Plan.never` if given an empty array.
     public static func every(_ weekdays: [Weekday]) -> DateMiddleware {
+        guard !weekdays.isEmpty else { return .init(plan: .never) }
+        
         var plan = every(weekdays[0]).plan
         if weekdays.count > 1 {
             for i in 1..<weekdays.count {
@@ -454,12 +476,16 @@ extension Plan {
     }
 
     /// Creates a plan that executes the task every specific days in the months.
+    /// - Note: Returns initialized with `Plan.never` if given no parameters.
     public static func every(_ mondays: Monthday...) -> DateMiddleware {
         return Plan.every(mondays)
     }
         
     /// Creates a plan that executes the task every specific days in the months.
+    /// - Note: Returns initialized with `Plan.never` if given an empty array.
     public static func every(_ mondays: [Monthday]) -> DateMiddleware {
+        guard !mondays.isEmpty else { return .init(plan: .never) }
+        
         var plan = every(mondays[0]).plan
         if mondays.count > 1 {
             for i in 1..<mondays.count {

--- a/Sources/Schedule/Plan.swift
+++ b/Sources/Schedule/Plan.swift
@@ -81,9 +81,15 @@ extension Plan {
         return Plan(sequence)
     }
 
-    /// Creates a plan from an interval array.
+    /// Creates a plan from a list of intervals.
     /// The task will be executed after each interval in the array.
     public static func of(_ intervals: Interval...) -> Plan {
+        return Plan.of(intervals)
+    }
+    
+    /// Creates a plan from a list of intervals.
+    /// The task will be executed after each interval in the array.
+    public static func of(_ intervals: [Interval]) -> Plan {
         return Plan(intervals)
     }
 }
@@ -133,9 +139,15 @@ extension Plan {
         return Plan.make(sequence.makeIterator)
     }
 
-    /// Creates a plan from a date array.
+    /// Creates a plan from a list of dates.
     /// The task will be executed at each date in the array.
     public static func of(_ dates: Date...) -> Plan {
+        return Plan.of(dates)
+    }
+    
+    /// Creates a plan from a list of dates.
+    /// The task will be executed at each date in the array.
+    public static func of(_ dates: [Date]) -> Plan {
         return Plan.from(dates)
     }
 
@@ -365,6 +377,16 @@ extension Plan {
         ///     .at(1, 2, 3)        => 01:02:03
         ///     .at(1, 2, 3, 456)   => 01:02:03.456
         public func at(_ time: Int...) -> Plan {
+            return self.at(time)
+        }
+
+        /// Returns a plan at the specific time.
+        ///
+        ///     .at([1])              => 01
+        ///     .at([1, 2])           => 01:02
+        ///     .at([1, 2, 3])        => 01:02:03
+        ///     .at([1, 2, 3, 456])   => 01:02:03.456
+        public func at(_ time: [Int]) -> Plan {
             let hour = time[0]
             let minute = time.count > 1 ? time[1] : 0
             let second = time.count > 2 ? time[2] : 0
@@ -398,6 +420,11 @@ extension Plan {
 
     /// Creates a plan that executes the task every specific weekdays.
     public static func every(_ weekdays: Weekday...) -> DateMiddleware {
+        return Plan.every(weekdays)
+    }
+    
+    /// Creates a plan that executes the task every specific weekdays.
+    public static func every(_ weekdays: [Weekday]) -> DateMiddleware {
         var plan = every(weekdays[0]).plan
         if weekdays.count > 1 {
             for i in 1..<weekdays.count {
@@ -428,6 +455,11 @@ extension Plan {
 
     /// Creates a plan that executes the task every specific days in the months.
     public static func every(_ mondays: Monthday...) -> DateMiddleware {
+        return Plan.every(mondays)
+    }
+        
+    /// Creates a plan that executes the task every specific days in the months.
+    public static func every(_ mondays: [Monthday]) -> DateMiddleware {
         var plan = every(mondays[0]).plan
         if mondays.count > 1 {
             for i in 1..<mondays.count {

--- a/Sources/Schedule/Plan.swift
+++ b/Sources/Schedule/Plan.swift
@@ -353,7 +353,7 @@ extension Plan {
 
         /// Returns a plan at the specific time.
         public func at(_ time: Time) -> Plan {
-            guard self.plan != .never else { return .never }
+            guard !self.plan.isNever() else { return .never }
             
             var interval = time.intervalSinceZeroClock
             return Plan.make { () -> AnyIterator<Interval> in
@@ -373,7 +373,7 @@ extension Plan {
         /// See Time's constructor
         public func at(_ time: String) -> Plan {
             guard
-                self.plan != .never,
+                !self.plan.isNever(),
                 let time = Time(time)
             else {
                 return .never
@@ -403,7 +403,7 @@ extension Plan {
         ///
         /// - Note: Returns `Plan.never` if given an empty array.
         public func at(_ time: [Int]) -> Plan {
-            guard !time.isEmpty, self.plan != .never else { return .never }
+            guard !time.isEmpty, !self.plan.isNever() else { return .never }
             
             let hour = time[0]
             let minute = time.count > 1 ? time[1] : 0
@@ -496,8 +496,8 @@ extension Plan {
     }
 }
 
-extension Plan: Equatable {
-    public static func == (lhs: Plan, rhs: Plan) -> Bool {
-        return lhs.sequence.elementsEqual(rhs.sequence)
+extension Plan {
+    public func isNever() -> Bool {
+        self.sequence.makeIterator().next() == nil
     }
 }

--- a/Tests/ScheduleTests/DateTimeTests.swift
+++ b/Tests/ScheduleTests/DateTimeTests.swift
@@ -22,7 +22,9 @@ final class DateTimeTests: XCTestCase {
         XCTAssertTrue(1.1.second.isLonger(than: 1.0.second))
         XCTAssertTrue(3.days.isShorter(than: 1.week))
         XCTAssertEqual(Interval.longest(1.hour, 1.day, 1.week), 1.week)
+        XCTAssertEqual(Interval.longest([]), .init(nanoseconds: 0))
         XCTAssertEqual(Interval.shortest(1.hour, 59.minutes, 2999.seconds), 2999.seconds)
+        XCTAssertEqual(Interval.shortest([]), .init(nanoseconds: 0))
 
         XCTAssertEqual(1.second * 60, 1.minute)
         XCTAssertEqual(59.minutes + 60.seconds, 1.hour)

--- a/Tests/ScheduleTests/PlanTests.swift
+++ b/Tests/ScheduleTests/PlanTests.swift
@@ -123,6 +123,18 @@ final class PlanTests: XCTestCase {
             XCTAssertEqual(i.dateComponents.hour, 11)
         }
     }
+    
+    func testPassingEmptyArrays() {
+        XCTAssertEqual(Plan.of([Interval]()), Plan.never)
+        XCTAssertEqual(Plan.of([Date]()), Plan.never)
+        
+        XCTAssertEqual(Plan.every([Weekday]()).at(11, 11), Plan.never)
+        XCTAssertEqual(Plan.every([Monthday]()).at(11, 11), Plan.never)
+        
+        XCTAssertEqual(Plan.every(.monday).at([]), Plan.never)
+        
+        XCTAssertEqual(Plan.every([Weekday]()).at("11:11:00"), Plan.never)
+    }
 
     static var allTests = [
         ("testMake", testMake),

--- a/Tests/ScheduleTests/PlanTests.swift
+++ b/Tests/ScheduleTests/PlanTests.swift
@@ -149,6 +149,7 @@ final class PlanTests: XCTestCase {
         ("testAfterAndRepeating", testAfterAndRepeating),
         ("testEveryPeriod", testEveryPeriod),
         ("testEveryWeekday", testEveryWeekday),
-        ("testEveryMonthday", testEveryMonthday)
+        ("testEveryMonthday", testEveryMonthday),
+        ("testPassingEmptyArrays", testPassingEmptyArrays),
     ]
 }

--- a/Tests/ScheduleTests/PlanTests.swift
+++ b/Tests/ScheduleTests/PlanTests.swift
@@ -125,15 +125,15 @@ final class PlanTests: XCTestCase {
     }
     
     func testPassingEmptyArrays() {
-        XCTAssertEqual(Plan.of([Interval]()), Plan.never)
-        XCTAssertEqual(Plan.of([Date]()), Plan.never)
+        XCTAssertTrue(Plan.of([Interval]()).isNever())
+        XCTAssertTrue(Plan.of([Date]()).isNever())
         
-        XCTAssertEqual(Plan.every([Weekday]()).at(11, 11), Plan.never)
-        XCTAssertEqual(Plan.every([Monthday]()).at(11, 11), Plan.never)
+        XCTAssertTrue(Plan.every([Weekday]()).at(11, 11).isNever())
+        XCTAssertTrue(Plan.every([Monthday]()).at(11, 11).isNever())
         
-        XCTAssertEqual(Plan.every(.monday).at([]), Plan.never)
+        XCTAssertTrue(Plan.every(.monday).at([]).isNever())
         
-        XCTAssertEqual(Plan.every([Weekday]()).at("11:11:00"), Plan.never)
+        XCTAssertTrue(Plan.every([Weekday]()).at("11:11:00").isNever())
     }
 
     static var allTests = [


### PR DESCRIPTION
Although it is cleaner to use a variadic function when creating schedules (ex. via `Plan.of(_ dates: Date...)`), sometimes it is necessary to pass an array instead of a list of parameters, like when dealing with data obtained at runtime. This PR adds that ability. For example, the `Plan.of(_:)` function can now take an array of `Date`s like so:

```swift
let dates = [Date(), Date(), Date(), Date(), Date()]
Plan.of(dates).do { ... }
```

The existing API has not changed whatsoever, the only difference being that the function implementations are now located in the array-variant of the function, and the existing variadic-variant (whose parameters are interpreted as an array in the function body) now simply passes its parameters into the array-variant.