### PR TITLE
Add return keyword in Plan.isNever

### DIFF
--- a/Sources/Schedule/Plan.swift
+++ b/Sources/Schedule/Plan.swift
@@ -498,6 +498,6 @@ extension Plan {
 
 extension Plan {
     public func isNever() -> Bool {
-        self.sequence.makeIterator().next() == nil
+        return self.sequence.makeIterator().next() == nil
     }
 }


### PR DESCRIPTION
Oops! For some reason nothing picked up that I forgot the `return` keyword in my last PR for `Plan.isNever`. This PR just adds that back to allow the project to build again.