### PR TITLE
General Improvements

### DIFF
--- a/Sources/Schedule/Bag.swift
+++ b/Sources/Schedule/Bag.swift
@@ -8,11 +8,6 @@ struct BagKey: Equatable {
     fileprivate init(underlying: UInt64) {
         self.i = underlying
     }
-
-    /// Returns a Boolean value indicating whether two BagKeys are equal.
-    static func == (lhs: BagKey, rhs: BagKey) -> Bool {
-        return lhs.i == rhs.i
-    }
 }
 
 /// A generator that can generate a sequence of unique `BagKey`.

--- a/Sources/Schedule/Bag.swift
+++ b/Sources/Schedule/Bag.swift
@@ -60,10 +60,7 @@ struct Bag<Element> {
 
     /// Returns the element associated with a given key.
     func value(for key: BagKey) -> Element? {
-        if let entry = entries.first(where: { $0.key == key }) {
-            return entry.val
-        }
-        return nil
+        return entries.first(where: { $0.key == key })?.val
     }
 
     /// Removes the given key and its associated element from this bag.

--- a/Sources/Schedule/Interval.swift
+++ b/Sources/Schedule/Interval.swift
@@ -12,13 +12,7 @@ public struct Interval {
     }
 }
 
-extension Interval: Hashable {
-
-    /// Returns a boolean value indicating whether two intervals are equal.
-    public static func == (lhs: Interval, rhs: Interval) -> Bool {
-        return lhs.nanoseconds == rhs.nanoseconds
-    }
-}
+extension Interval: Hashable { }
 
 extension Interval {
 

--- a/Sources/Schedule/Period.swift
+++ b/Sources/Schedule/Period.swift
@@ -72,7 +72,7 @@ public struct Period {
         let mark: Character = "秋"
         str = regexp.stringByReplacingMatches(
             in: str,
-            range: NSRange(location: 0, length: str.count),
+            range: NSRange(str.startIndex..., in: str),
             withTemplate: String(mark)
         )
 

--- a/Sources/Schedule/Period.swift
+++ b/Sources/Schedule/Period.swift
@@ -85,7 +85,7 @@ public struct Period {
                 return nil
             }
 
-            var unit = String(pair[1])
+            var unit = pair[1]
             if unit.last == "s" { unit.removeLast() }
             switch unit {
             case "year":            period = period + number.years

--- a/Sources/Schedule/Plan.swift
+++ b/Sources/Schedule/Plan.swift
@@ -473,10 +473,8 @@ extension Plan {
         guard !mondays.isEmpty else { return .init(plan: .never) }
 
         var plan = every(mondays[0]).plan
-        if mondays.count > 1 {
-            for i in 1..<mondays.count {
-                plan = plan.merge(Plan.every(mondays[i]).plan)
-            }
+        for monday in mondays.dropFirst() {
+            plan = plan.merge(Plan.every(monday).plan)
         }
         return DateMiddleware(plan: plan)
     }

--- a/Sources/Schedule/Plan.swift
+++ b/Sources/Schedule/Plan.swift
@@ -435,10 +435,8 @@ extension Plan {
         guard !weekdays.isEmpty else { return .init(plan: .never) }
 
         var plan = every(weekdays[0]).plan
-        if weekdays.count > 1 {
-            for i in 1..<weekdays.count {
-                plan = plan.merge(Plan.every(weekdays[i]).plan)
-            }
+        for weekday in weekdays.dropFirst() {
+            plan = plan.merge(Plan.every(weekday).plan)
         }
         return DateMiddleware(plan: plan)
     }

--- a/Sources/Schedule/TaskCenter.swift
+++ b/Sources/Schedule/TaskCenter.swift
@@ -8,15 +8,12 @@ extension TaskCenter {
 
         weak var task: Task?
 
-        let hash: Int
-
         init(_ task: Task) {
             self.task = task
-            self.hash = task.hashValue
         }
 
         func hash(into hasher: inout Hasher) {
-            hasher.combine(hash)
+            hasher.combine(task)
         }
 
         static func == (lhs: TaskBox, rhs: TaskBox) -> Bool {

--- a/Sources/Schedule/Time.swift
+++ b/Sources/Schedule/Time.swift
@@ -62,6 +62,7 @@ public struct Time {
         var hasAM = false
         var hasPM = false
         var values: [Int] = []
+        values.reserveCapacity(matches.numberOfRanges)
 
         for i in 0..<matches.numberOfRanges {
             let range = matches.range(at: i)

--- a/Sources/Schedule/Time.swift
+++ b/Sources/Schedule/Time.swift
@@ -50,10 +50,11 @@ public struct Time {
 
         // swiftlint:disable force_try
         let regexp = try! NSRegularExpression(pattern: pattern, options: [])
+        let nsString = NSString(string: string)
         guard let matches = regexp.matches(
             in: string,
             options: [],
-            range: NSRange(location: 0, length: string.count)).first
+            range: NSRange(location: 0, length: nsString.length)).first
         else {
             return nil
         }
@@ -65,7 +66,7 @@ public struct Time {
         for i in 0..<matches.numberOfRanges {
             let range = matches.range(at: i)
             if range.length == 0 { continue }
-            let captured = NSString(string: string).substring(with: range)
+            let captured = nsString.substring(with: range)
             hasAM = ["am", "AM"].contains(captured)
             hasPM = ["pm", "PM"].contains(captured)
             if let value = Int(captured) {


### PR DESCRIPTION
- Use default implementation where equivalent
- More efficient collection handling
- <details><summary>Construct NSRange using the proper method</summary>String.count is number of Characters, but NSRange uses utf16.count. There won’t be any problem if a properly formatted string is passed in, but the current implementation will fail in other scenarios.</details>