### PR TITLE
fix error: cannot find 'CFRunLoopTimerCreateWithHandler' in scope

### DIFF
--- a/Sources/Schedule/RunLoopTask.swift
+++ b/Sources/Schedule/RunLoopTask.swift
@@ -58,11 +58,22 @@ private final class RunLoopTask: Task {
             guard let task = task as? RunLoopTask, let timer = task.timer else { return }
             timer.fireDate = Date()
         }
+
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
         
         timer = CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, Date.distantFuture.timeIntervalSinceReferenceDate, .greatestFiniteMagnitude, 0, 0, { [weak self] _ in
             guard let self = self else { return }
             action(self)
         })
+
+        #elseif os(Linux)
+
+        timer = Timer(fire: Date.distantFuture, interval: .greatestFiniteMagnitude, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            action(self)
+        }
+
+        #endif
 
         RunLoop.current.add(timer, forMode: mode)
     }


### PR DESCRIPTION
Issue: https://github.com/luoxiu/Schedule/issues/60
Description: Regression was introduce in 2.0.3: https://github.com/luoxiu/Schedule/commit/c3ee993fa94c5e1ec278bd28632c91136d0e2f68